### PR TITLE
Jira might return lower number than maxResults

### DIFF
--- a/R/Project2R.R
+++ b/R/Project2R.R
@@ -560,8 +560,13 @@ basic_issues_info<-function(x){
 
 parse_issue<-function(issue, JirAgileR_id){
   issue<-issue[lengths(issue) != 0]
-  available_fields<-names(issue)
+  ## parse known fields
+  available_fields<-intersect(names(issue), supported_jql_fields())
   res<-lapply(available_fields, function (y) choose_field_function(issue, y))
+  ## keep custom fields as is
+  for (customfield in grep('^customfield', names(issue), value = TRUE)) {
+    res[[customfield]] <- issue[[customfield]]
+  }
   id<-data.frame("JirAgileR_id"=JirAgileR_id, stringsAsFactors = FALSE)
   df<-do.call(cbind, res)
   if(!is.null(df) && length(df)>0){

--- a/R/Project2R.R
+++ b/R/Project2R.R
@@ -501,7 +501,7 @@ get_jira_issues <- function(domain=NULL,
   issue_list <- list()
   i <- 0
   repeat{
-    url$query$startAt <- 0 + i*maxResults
+    url$query$startAt <- length(issue_list)
     url_b <- httr::build_url(url)
     call_raw <- httr::GET(url_b,  encode = "json", if(verbose){httr::verbose()}, auth, httr::user_agent("github.com/matbmeijer/JirAgileR"))
     if(httr::http_error(call_raw$status_code)){

--- a/R/Project2R.R
+++ b/R/Project2R.R
@@ -520,6 +520,9 @@ get_jira_issues <- function(domain=NULL,
       break
     }
   }
+  if(length(issue_list) == 0){
+    return(setNames(data.frame(matrix(ncol = length(fields), nrow = 0)), fields))
+  }
   base_info <- basic_issues_info(issue_list)
   ext_info <- lapply(issue_list, `[[`, "fields")
   if(as.data.frame){


### PR DESCRIPTION
Hi,

I needed to make these adjustments to be able to

* query tickets with `maxResults` not being set to the default 50, but eg 1000 (making it higher resulted in less paging -- despite the fact that Jira still limits this to something lower than the set value, as it will be usually more than 50)
* query custom fields

No hard feeling if not accepted into the upstream package, but wanted to share as might be useful for others as well.

Best,
Gergely